### PR TITLE
Fix varargs use

### DIFF
--- a/log.c
+++ b/log.c
@@ -389,36 +389,29 @@ static int _log_iterator_next(_log_iterator *it, int level)
   return 0;
 }
 
-static void _log_iterator_vprintf_nl(_log_iterator *it, int level, struct __sourceloc whence, const char *fmt, va_list ap)
-{
-  _log_iterator_rewind(it);
-  while (_log_iterator_next(it, level)) {
-    _log_prefix_whence(it, whence);
-    vxprintf(it->xpf, fmt, ap);
-  }
-}
-
 static void _log_iterator_printf_nl(_log_iterator *it, int level, struct __sourceloc whence, const char *fmt, ...)
 {
   va_list ap;
-  va_start(ap, fmt);
-  _log_iterator_vprintf_nl(it, level, whence, fmt, ap);
-  va_end(ap);
-}
-
-static void _logs_vprintf_nl(int level, struct __sourceloc whence, const char *fmt, va_list ap)
-{
-  _log_iterator it;
-  _log_iterator_start(&it);
-  _log_iterator_vprintf_nl(&it, level, whence, fmt, ap);
+  _log_iterator_rewind(it);
+  while (_log_iterator_next(it, level)) {
+    _log_prefix_whence(it, whence);
+    va_start(ap, fmt);
+    vxprintf(it->xpf, fmt, ap);
+    va_end(ap);
+  }
 }
 
 static void _logs_printf_nl(int level, struct __sourceloc whence, const char *fmt, ...)
 {
   va_list ap;
-  va_start(ap, fmt);
-  _logs_vprintf_nl(level, whence, fmt, ap);
-  va_end(ap);
+  _log_iterator it;
+  _log_iterator_start(&it);
+  while (_log_iterator_next(&it, level)) {
+    _log_prefix_whence(&it, whence);
+    va_start(ap, fmt);
+    vxprintf(it.xpf, fmt, ap);
+    va_end(ap);
+  }
 }
 
 const char *log_file_directory_path()
@@ -681,23 +674,16 @@ void logString(int level, struct __sourceloc whence, const char *str)
 
 void logMessage(int level, struct __sourceloc whence, const char *fmt, ...)
 {
-  if (level != LOG_LEVEL_SILENT) {
-    va_list ap;
-    va_start(ap, fmt);
-    vlogMessage(level, whence, fmt, ap);
-    va_end(ap);
-  }
-}
-
-void vlogMessage(int level, struct __sourceloc whence, const char *fmt, va_list ap)
-{
+  va_list ap;
   if (level != LOG_LEVEL_SILENT) {
     _log_iterator it;
     _log_iterator_start(&it);
     _rotate_log_file(&it);
     while (_log_iterator_next(&it, level)) {
       _log_prefix_whence(&it, whence);
+      va_start(ap, fmt);
       vxprintf(it.xpf, fmt, ap);
+      va_end(ap);
     }
   }
 }


### PR DESCRIPTION
[forum thread](https://groups.google.com/forum/#!topic/serval-project-developers/tCF8hP1j6KM)

`man stdarg` says:

> If ap is passed to a function that uses va_arg(ap,type) then the value
> of ap is undefined after the return of that function.

`va_start(…)` and `va_end(…)` must be called at each iteration.

By chance, it worked in 32 bits, but it segfaulted in 64 bits.

See http://gcc.gnu.org/bugzilla/show_bug.cgi?id=31484
