### PR TITLE
ob_dup() did not preserve source position

### DIFF
--- a/overlay_buffer.c
+++ b/overlay_buffer.c
@@ -90,6 +90,8 @@ struct overlay_buffer *ob_dup(struct overlay_buffer *b){
       byteCount = b->allocSize;
     
     ob_append_bytes(ret, b->bytes, byteCount);
+    /* position must be reset after ob_append_bytes */
+    ret->position = b->position;
   }
   return ret;
 }


### PR DESCRIPTION
ob_append_bytes() changes the position, so it must be reset.
