### PR TITLE
Rhizome parallelization

### DIFF
--- a/commandline.c
+++ b/commandline.c
@@ -220,7 +220,7 @@ JNIEXPORT jint JNICALL Java_org_servalproject_servald_ServalD_rawCommand(JNIEnv 
 */
 int parseCommandLine(struct cli_context *context, const char *argv0, int argc, const char *const *args)
 {
-  fd_clearstats();
+  fd_clearstats(current_fdqueue());
   IN();
   
   struct cli_parsed parsed;
@@ -255,8 +255,12 @@ int parseCommandLine(struct cli_context *context, const char *argv0, int argc, c
   rhizome_close_db();
   OUT();
   
-  if (config.debug.timing)
-    fd_showstats();
+  if (config.debug.timing) {
+    INFO("Main thread stats:");
+    fd_showstats(&main_fdqueue);
+    INFO("Rhizome thread stats:");
+    fd_showstats(&rhizome_fdqueue);
+  }
   return result;
 }
 

--- a/commandline.c
+++ b/commandline.c
@@ -228,9 +228,11 @@ int parseCommandLine(struct cli_context *context, const char *argv0, int argc, c
   switch (result) {
   case 0:
     // Do not run the command if the configuration does not load ok.
-    if (((parsed.commands[parsed.cmdi].flags & CLIFLAG_PERMISSIVE_CONFIG) ? cf_reload_permissive() : cf_reload()) != -1)
+    if (((parsed.commands[parsed.cmdi].flags & CLIFLAG_PERMISSIVE_CONFIG) ? cf_reload_permissive() : cf_reload()) != -1) {
+      fdqueues_init();
       result = cli_invoke(&parsed, context);
-    else {
+      fdqueues_free();
+    } else {
       strbuf b = strbuf_alloca(160);
       strbuf_append_argv(b, argc, args);
       result = WHYF("configuration defective, not running command: %s", strbuf_str(b));

--- a/fdqueue.c
+++ b/fdqueue.c
@@ -18,43 +18,63 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
 #include <poll.h>
+#include <pthread.h>
 #include "serval.h"
 #include "conf.h"
 #include "str.h"
 #include "strbuf.h"
 #include "strbuf_helpers.h"
+#include "fdqueue.h"
 
-#define MAX_WATCHED_FDS 128
-struct pollfd fds[MAX_WATCHED_FDS];
-int fdcount=0;
-struct sched_ent *fd_callbacks[MAX_WATCHED_FDS];
-struct sched_ent *next_alarm=NULL;
-struct sched_ent *next_deadline=NULL;
-struct profile_total poll_stats={NULL,0,"Idle (in poll)",0,0,0};
+#ifndef PTHREAD_RECURSIVE_MUTEX_INITIALIZER
+#define PTHREAD_RECURSIVE_MUTEX_INITIALIZER \
+  PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
+#endif
+
+fdqueue main_fdqueue = {
+  .poll_stats = { .name = "Main fdqueue" },
+  .mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER,
+  .cond_is_active = PTHREAD_COND_INITIALIZER,
+  .cond_change = PTHREAD_COND_INITIALIZER
+};
+
+fdqueue rhizome_fdqueue = {
+  .poll_stats = { .name = "Rhizome fdqueue" },
+  .mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER,
+  .cond_is_active = PTHREAD_COND_INITIALIZER,
+  .cond_change = PTHREAD_COND_INITIALIZER
+};
+
+static inline int is_active(fdqueue *fdq) {
+  return fdq->next_alarm || fdq->next_deadline || fdq->fdcount > 0;
+}
 
 #define alloca_alarm_name(alarm) ((alarm)->stats ? alloca_str_toprint((alarm)->stats->name) : "Unnamed")
 
-void list_alarms()
+void list_alarms(fdqueue *fdq)
 {
   DEBUG("Alarms;");
+  pthread_mutex_lock(&fdq->mutex);
   time_ms_t now = gettime_ms();
   struct sched_ent *alarm;
   
-  for (alarm = next_deadline; alarm; alarm = alarm->_next)
+  for (alarm = fdq->next_deadline; alarm; alarm = alarm->_next)
     DEBUGF("%p %s deadline in %lldms", alarm->function, alloca_alarm_name(alarm), alarm->deadline - now);
   
-  for (alarm = next_alarm; alarm; alarm = alarm->_next)
+  for (alarm = fdq->next_alarm; alarm; alarm = alarm->_next)
     DEBUGF("%p %s in %lldms, deadline in %lldms", alarm->function, alloca_alarm_name(alarm), alarm->alarm - now, alarm->deadline - now);
   
   DEBUG("File handles;");
   int i;
-  for (i = 0; i < fdcount; ++i)
-    DEBUGF("%s watching #%d", alloca_alarm_name(fd_callbacks[i]), fds[i].fd);
+  for (i = 0; i < fdq->fdcount; ++i)
+    DEBUGF("%s watching #%d", alloca_alarm_name(fdq->fd_callbacks[i]), fdq->fds[i].fd);
+  pthread_mutex_unlock(&fdq->mutex);
 }
 
-int deadline(struct sched_ent *alarm)
+static int deadline(struct sched_ent *alarm)
 {
-  struct sched_ent *node = next_deadline, *last = NULL;
+  fdqueue *fdq = alarm->fdqueue;
+  struct sched_ent *node = fdq->next_deadline, *last = NULL;
   if (alarm->deadline < alarm->alarm)
     alarm->deadline = alarm->alarm;
   
@@ -65,7 +85,7 @@ int deadline(struct sched_ent *alarm)
     node = node->_next;
   }
   if (last == NULL){
-    next_deadline = alarm;
+    fdq->next_deadline = alarm;
   }else{
     last->_next = alarm;
   }
@@ -78,7 +98,16 @@ int deadline(struct sched_ent *alarm)
 
 int is_scheduled(const struct sched_ent *alarm)
 {
-  return alarm->_next || alarm->_prev || alarm == next_alarm || alarm == next_deadline;
+  fdqueue *fdq = alarm->fdqueue;
+  if (!fdq) {
+    return 0;
+  }
+  int res;
+  pthread_mutex_lock(&fdq->mutex);
+  res = alarm->_next || alarm->_prev || alarm == fdq->next_alarm
+    || alarm == fdq->next_deadline;
+  pthread_mutex_unlock(&fdq->mutex);
+  return res;
 }
 
 // add an alarm to the list of scheduled function calls.
@@ -94,14 +123,27 @@ int _schedule(struct __sourceloc __whence, struct sched_ent *alarm)
     WARNF("schedule() called from %s() %s:%d without supplying an alarm name", 
 	  __whence.function,__whence.file,__whence.line);
 
-  struct sched_ent *node = next_alarm, *last = NULL;
-  
-  if (is_scheduled(alarm))
-    FATAL("Scheduling an alarm that is already scheduled");
-  
   if (!alarm->function)
     return WHY("Can't schedule if you haven't set the function pointer");
-  
+
+  fdqueue *fdq = alarm->fdqueue;
+  if (!fdq) {
+    fdq = alarm->fdqueue = &main_fdqueue;
+  }
+
+  pthread_mutex_lock(&fdq->mutex);
+  struct sched_ent *node = fdq->next_alarm, *last = NULL;
+
+  if (is_scheduled(alarm)) {
+    pthread_mutex_unlock(&fdq->mutex);
+    FATAL("Scheduling an alarm that is already scheduled");
+  }
+
+  if (!is_active(fdq)) {
+    /* it will become active before releasing the mutex */
+    pthread_cond_signal(&fdq->cond_is_active);
+  }
+
   time_ms_t now = gettime_ms();
 
   if (alarm->deadline < alarm->alarm)
@@ -116,9 +158,13 @@ int _schedule(struct __sourceloc __whence, struct sched_ent *alarm)
   }
 
   // if the alarm has already expired, move straight to the deadline queue
-  if (alarm->alarm <= now)
-    return deadline(alarm);
-  
+  if (alarm->alarm <= now) {
+    int res = deadline(alarm);
+    pthread_cond_signal(&fdq->cond_change);
+    pthread_mutex_unlock(&fdq->mutex);
+    return res;
+  }
+
   while(node!=NULL){
     if (node->alarm > alarm->alarm)
       break;
@@ -126,7 +172,8 @@ int _schedule(struct __sourceloc __whence, struct sched_ent *alarm)
     node = node->_next;
   }
   if (last == NULL){
-    next_alarm = alarm;
+    fdq->next_alarm = alarm;
+    pthread_cond_signal(&fdq->cond_change);
   }else{
     last->_next=alarm;
   }
@@ -134,7 +181,9 @@ int _schedule(struct __sourceloc __whence, struct sched_ent *alarm)
   if(node!=NULL)
     node->_prev = alarm;
   alarm->_next = node;
-  
+
+  pthread_mutex_unlock(&fdq->mutex);
+
   return 0;
 }
 
@@ -145,21 +194,35 @@ int _unschedule(struct __sourceloc __whence, struct sched_ent *alarm)
   if (config.debug.io)
     DEBUGF("unschedule(alarm=%s)", alloca_alarm_name(alarm));
 
+  fdqueue *fdq = alarm->fdqueue;
+  if (!fdq) {
+    /* was never scheduled */
+    return 0;
+  }
+
+  pthread_mutex_lock(&fdq->mutex);
+
   struct sched_ent *prev = alarm->_prev;
   struct sched_ent *next = alarm->_next;
   
-  if (prev)
+  if (prev) {
     prev->_next = next;
-  else if(next_alarm==alarm)
-    next_alarm = next;
-  else if(next_deadline==alarm)
-    next_deadline = next;
+  } else if (fdq->next_alarm == alarm) {
+    fdq->next_alarm = next;
+    pthread_cond_signal(&fdq->cond_change);
+  } else if (fdq->next_deadline == alarm) {
+    fdq->next_deadline = next;
+    pthread_cond_signal(&fdq->cond_change);
+  }
   
   if (next)
     next->_prev = prev;
   
   alarm->_prev = NULL;
   alarm->_next = NULL;
+
+  pthread_mutex_unlock(&fdq->mutex);
+
   return 0;
 }
 
@@ -174,22 +237,40 @@ int _watch(struct __sourceloc __whence, struct sched_ent *alarm)
 
   if (!alarm->function)
     return WHY("Can't watch if you haven't set the function pointer");
-  
-  if (alarm->_poll_index>=0 && fd_callbacks[alarm->_poll_index]==alarm){
+
+  fdqueue *fdq = alarm->fdqueue;
+  if (!fdq) {
+    fdq = alarm->fdqueue = &main_fdqueue;
+  }
+
+  pthread_mutex_lock(&fdq->mutex);
+
+  if (!is_active(fdq)) {
+    /* it will become active before releasing the mutex */
+    pthread_cond_signal(&fdq->cond_is_active);
+  }
+  pthread_cond_signal(&fdq->cond_change);
+
+  if (alarm->_poll_index >= 0 && fdq->fd_callbacks[alarm->_poll_index] == alarm) {
     // updating event flags
     if (config.debug.io)
       DEBUGF("Updating watch %s, #%d for %d", alloca_alarm_name(alarm), alarm->poll.fd, alarm->poll.events);
   }else{
     if (config.debug.io)
       DEBUGF("Adding watch %s, #%d for %d", alloca_alarm_name(alarm), alarm->poll.fd, alarm->poll.events);
-    if (fdcount>=MAX_WATCHED_FDS)
+    if (fdq->fdcount >= MAX_WATCHED_FDS) {
+      pthread_mutex_unlock(&fdq->mutex);
       return WHY("Too many file handles to watch");
-    fd_callbacks[fdcount]=alarm;
+    }
+    fdq->fd_callbacks[fdq->fdcount] = alarm;
     alarm->poll.revents = 0;
-    alarm->_poll_index=fdcount;
-    fdcount++;
+    alarm->_poll_index = fdq->fdcount;
+    fdq->fdcount++;
   }
-  fds[alarm->_poll_index]=alarm->poll;
+  fdq->fds[alarm->_poll_index] = alarm->poll;
+
+  pthread_mutex_unlock(&fdq->mutex);
+
   return 0;
 }
 
@@ -199,22 +280,31 @@ int _unwatch(struct __sourceloc __whence, struct sched_ent *alarm)
   if (config.debug.io)
     DEBUGF("unwatch(alarm=%s)", alloca_alarm_name(alarm));
 
+  fdqueue *fdq = alarm->fdqueue;
+
+  pthread_mutex_lock(&fdq->mutex);
+
   int index = alarm->_poll_index;
-  if (index <0 || fds[index].fd!=alarm->poll.fd)
+  if (index < 0 || fdq->fds[index].fd != alarm->poll.fd) {
+    pthread_mutex_unlock(&fdq->mutex);
     return WHY("Attempted to unwatch a handle that is not being watched");
-  
-  fdcount--;
-  if (index!=fdcount){
-    // squash fds
-    fds[index] = fds[fdcount];
-    fd_callbacks[index] = fd_callbacks[fdcount];
-    fd_callbacks[index]->_poll_index=index;
   }
-  fds[fdcount].fd=-1;
-  fd_callbacks[fdcount]=NULL;
+
+  fdq->fdcount--;
+  if (index != fdq->fdcount) {
+    // squash fds
+    fdq->fds[index] = fdq->fds[fdq->fdcount];
+    fdq->fd_callbacks[index] = fdq->fd_callbacks[fdq->fdcount];
+    fdq->fd_callbacks[index]->_poll_index = index;
+  }
+  fdq->fds[fdq->fdcount].fd = -1;
+  fdq->fd_callbacks[fdq->fdcount] = NULL;
   alarm->_poll_index=-1;
   if (config.debug.io)
     DEBUGF("%s stopped watching #%d for %d", alloca_alarm_name(alarm), alarm->poll.fd, alarm->poll.events);
+
+  pthread_mutex_unlock(&fdq->mutex);
+
   return 0;
 }
 
@@ -223,6 +313,7 @@ static void call_alarm(struct sched_ent *alarm, int revents)
   IN();
   if (!alarm)
     FATAL("Attempted to call with no alarm");
+  fdqueue *fdq = alarm->fdqueue;
   struct call_stats call_stats;
   call_stats.totals = alarm->stats;
   
@@ -233,7 +324,9 @@ static void call_alarm(struct sched_ent *alarm, int revents)
     fd_func_enter(__HERE__, &call_stats);
   
   alarm->poll.revents = revents;
+  pthread_mutex_unlock(&fdq->mutex);
   alarm->function(alarm);
+  pthread_mutex_lock(&fdq->mutex);
   
   if (call_stats.totals)
     fd_func_exit(__HERE__, &call_stats);
@@ -243,110 +336,137 @@ static void call_alarm(struct sched_ent *alarm, int revents)
   OUT();
 }
 
-int fd_poll()
+int fd_poll(fdqueue *fdq, int wait)
 {
   IN();
+  pthread_mutex_lock(&fdq->mutex);
   int i, r=0;
-  int ms=60000;
-  time_ms_t now = gettime_ms();
-  
-  if (!next_alarm && !next_deadline && fdcount==0)
-    RETURN(0);
-  
-  /* move alarms that have elapsed to the deadline queue */
-  while (next_alarm!=NULL&&next_alarm->alarm <=now){
-    struct sched_ent *alarm = next_alarm;
-    unschedule(alarm);
-    deadline(alarm);
-  }
-  
-  /* work out how long we can block in poll */
-  if (next_deadline)
-    ms = 0;
-  else if (next_alarm){
-    ms = next_alarm->alarm - now;
-  }
-  
-  /* Make sure we don't have any silly timeouts that will make us wait forever. */
-  if (ms<0) ms=0;
-  
-  /* check if any file handles have activity */
-  {
+  int invalidated;
+  int ms;
+  time_ms_t now;
+
+  do {
+    invalidated = 0;
+    if (wait) {
+      while (!is_active(fdq)) {
+        pthread_cond_wait(&fdq->cond_is_active, &fdq->mutex);
+      }
+    } else {
+      if (!is_active(fdq)) {
+        pthread_mutex_unlock(&fdq->mutex);
+        RETURN(0);
+      }
+    }
+
+    now = gettime_ms();
+
+    /* move alarms that have elapsed to the deadline queue */
+    while (fdq->next_alarm && fdq->next_alarm->alarm <= now) {
+      struct sched_ent *alarm = fdq->next_alarm;
+      unschedule(alarm);
+      deadline(alarm);
+    }
+
+    /* check if any file handles have activity */
     struct call_stats call_stats;
-    call_stats.totals=&poll_stats;
+    call_stats.totals = &fdq->poll_stats;
     fd_func_enter(__HERE__, &call_stats);
-    if (fdcount==0){
-      if (ms>=1000)
-	sleep(ms/1000);
-      else
-	usleep(ms*1000);
-    }else{
-      if (config.debug.io) DEBUGF("poll(X,%d,%d)",fdcount,ms);
-      r = poll(fds, fdcount, ms);
+    if (fdq->fdcount == 0) {
+      if (fdq->fdcount == 0 && !fdq->next_deadline) {
+        /* wait for the next alarm or the next change */
+        struct timespec timeout;
+        MS_TO_TIMESPEC(fdq->next_alarm->alarm, &timeout);
+        int retcode =
+          pthread_cond_timedwait(&fdq->cond_change, &fdq->mutex, &timeout);
+        invalidated = retcode != ETIMEDOUT;
+      }
+    } else {
+      if (fdq->next_deadline) {
+        ms = 0;
+      } else if (fdq->next_alarm) {
+        ms = fdq->next_alarm->alarm - now;
+        if (ms < 0) {
+          ms = 0;
+        }
+      } else {
+        /* infinite timeout */
+        ms = -1;
+        // TODO for the moment, we don't interrupt poll, so we wait only for
+        // 1 second
+        ms = 1000;
+      }
+
+      if (config.debug.io) DEBUGF("poll(X,%d,%d)", fdq->fdcount, ms);
+      r = poll(fdq->fds, fdq->fdcount, ms);
+
       if (config.debug.io) {
-	strbuf b = strbuf_alloca(1024);
-	int i;
-	for (i = 0; i < fdcount; ++i) {
-	  if (i)
-	    strbuf_puts(b, ", ");
-	  strbuf_sprintf(b, "%d:", fds[i].fd);
-	  strbuf_append_poll_events(b, fds[i].events);
-	  strbuf_putc(b, ':');
-	  strbuf_append_poll_events(b, fds[i].revents);
-	}
-	DEBUGF("poll(fds=(%s), fdcount=%d, ms=%d) = %d", strbuf_str(b), fdcount, ms, r);
+        strbuf b = strbuf_alloca(1024);
+        int i;
+        for (i = 0; i < fdq->fdcount; ++i) {
+          if (i)
+            strbuf_puts(b, ", ");
+          strbuf_sprintf(b, "%d:", fdq->fds[i].fd);
+          strbuf_append_poll_events(b, fdq->fds[i].events);
+          strbuf_putc(b, ':');
+          strbuf_append_poll_events(b, fdq->fds[i].revents);
+        }
+        DEBUGF("poll(fds=(%s), fdcount=%d, ms=%d) = %d", strbuf_str(b), fdq->fdcount, ms, r);
       }
     }
     fd_func_exit(__HERE__, &call_stats);
     now=gettime_ms();
-  }
+  } while (invalidated);
 
   // Reading new data takes priority over everything else
   // Are any handles marked with POLLIN?
-  int in_count=0;
-  if (r>0){
-    for (i=0;i<fdcount;i++)
-      if (fds[i].revents & POLLIN)
+  int in_count = 0;
+  if (r > 0) {
+    for (i = 0; i < fdq->fdcount; i++)
+      if (fdq->fds[i].revents & POLLIN)
         in_count++;
   }
 
   /* call one alarm function, but only if its deadline time has elapsed OR there is no incoming file activity */
-  if (next_deadline && (next_deadline->deadline <=now || (in_count==0))){
-    struct sched_ent *alarm = next_deadline;
+  if (fdq->next_deadline && (fdq->next_deadline->deadline <= now || in_count == 0)) {
+    struct sched_ent *alarm = fdq->next_deadline;
     unschedule(alarm);
     call_alarm(alarm, 0);
     now=gettime_ms();
 
     // after running a timed alarm, unless we already know there is data to read we want to check for more incoming IO before we send more outgoing.
-    if (in_count==0)
+    if (in_count==0) {
+      pthread_mutex_unlock(&fdq->mutex);
       RETURN(1);
+    }
   }
   
   /* If file descriptors are ready, then call the appropriate functions */
-  if (r>0) {
-    for(i=fdcount -1;i>=0;i--){
-      if (fds[i].revents) {
+  if (r > 0) {
+    for (i = fdq->fdcount -1; i >= 0; i--){
+      if (fdq->fds[i].revents) {
         // if any handles have POLLIN set, don't process any other handles
-        if (!(fds[i].revents&POLLIN || in_count==0))
+        if (!(fdq->fds[i].revents & POLLIN || in_count == 0))
           continue;
-
-	int fd = fds[i].fd;
-	/* Call the alarm callback with the socket in non-blocking mode */
-	errno=0;
-	set_nonblock(fd);
-	// Work around OSX behaviour that doesn't set POLLERR on 
-	// devices that have been deconfigured, e.g., a USB serial adapter
-	// that has been removed.
-	if (errno == ENXIO) fds[i].revents|=POLLERR;
-	call_alarm(fd_callbacks[i], fds[i].revents);
-	/* The alarm may have closed and unwatched the descriptor, make sure this descriptor still matches */
-	if (i<fdcount && fds[i].fd == fd){
-	  if (set_block(fds[i].fd))
-	    FATALF("Alarm %p %s has a bad descriptor that wasn't closed!", fd_callbacks[i], alloca_alarm_name(fd_callbacks[i]));
-	}
+        int fd = fdq->fds[i].fd;
+        /* Call the alarm callback with the socket in non-blocking mode */
+        errno=0;
+        set_nonblock(fd);
+        // Work around OSX behaviour that doesn't set POLLERR on
+        // devices that have been deconfigured, e.g., a USB serial adapter
+        // that has been removed.
+        if (errno == ENXIO) fdq->fds[i].revents|=POLLERR;
+        call_alarm(fdq->fd_callbacks[i], fdq->fds[i].revents);
+        /* The alarm may have closed and unwatched the descriptor, make sure this descriptor still matches */
+        if (i < fdq->fdcount && fdq->fds[i].fd == fd){
+          if (set_block(fdq->fds[i].fd))
+            FATALF("Alarm %p %s has a bad descriptor that wasn't closed!", fdq->fd_callbacks[i], alloca_alarm_name(fdq->fd_callbacks[i]));
+        }
       }
     }
   }
+
+  pthread_mutex_unlock(&fdq->mutex);
+
   RETURN(1);
   OUT();
 }

--- a/fdqueue.h
+++ b/fdqueue.h
@@ -58,12 +58,16 @@ typedef struct fdqueue {
    * fd is being watched */
   pthread_cond_t cond_change;
 
+  /* for performance_timing.c */
+  struct profile_total *stats_head;
+  struct call_stats *current_call;
+
 } fdqueue;
 
 void fdqueues_init(void);
 void fdqueues_free(void);
 
 /* return the fdqueue associated to the current thread */
-fdqueue *current_fdqueue();
+fdqueue *current_fdqueue(void);
 
 #endif

--- a/fdqueue.h
+++ b/fdqueue.h
@@ -33,7 +33,11 @@ extern struct fdqueue rhizome_fdqueue;
 
 typedef struct fdqueue {
 
-  struct pollfd fds[MAX_WATCHED_FDS];
+  /* a pipe fd is added at intfds[0] for interrupting poll() */
+  int pipefd[2];
+  struct pollfd intfds[MAX_WATCHED_FDS+1];
+
+  struct pollfd *fds; /* must be initialized to intfds + 1 */
   int fdcount;
   struct sched_ent *fd_callbacks[MAX_WATCHED_FDS];
   struct sched_ent *next_alarm;
@@ -55,5 +59,11 @@ typedef struct fdqueue {
   pthread_cond_t cond_change;
 
 } fdqueue;
+
+void fdqueues_init(void);
+void fdqueues_free(void);
+
+/* return the fdqueue associated to the current thread */
+fdqueue *current_fdqueue();
 
 #endif

--- a/fdqueue.h
+++ b/fdqueue.h
@@ -1,0 +1,59 @@
+/*
+ Copyright (C) 2012 Serval Project.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ 02110-1301, USA.
+ */
+
+#ifndef __SERVALD_FDQUEUE_H
+#define __SERVALD_FDQUEUE_H
+
+#include <pthread.h>
+#include "serval.h"
+
+#define MAX_WATCHED_FDS 128
+
+/* fdqueue used for all actions (including MDP) except Rhizome */
+extern struct fdqueue main_fdqueue;
+
+/* fdqueue used for Rhizome actions */
+extern struct fdqueue rhizome_fdqueue;
+
+typedef struct fdqueue {
+
+  struct pollfd fds[MAX_WATCHED_FDS];
+  int fdcount;
+  struct sched_ent *fd_callbacks[MAX_WATCHED_FDS];
+  struct sched_ent *next_alarm;
+  struct sched_ent *next_deadline;
+  struct profile_total poll_stats;
+
+  /* thread associated with the fdqueue */
+  pthread_t thread;
+
+  /* mutex to be acquired for every fdqueue items access */
+  pthread_mutex_t mutex;
+
+  /* signaled when the queue state changes from inactive to active (see
+   * is_active(fdqueue *) in fdqueue.c) */
+  pthread_cond_t cond_is_active;
+
+  /* signaled when next_alarm or next_deadline is changed or when a new
+   * fd is being watched */
+  pthread_cond_t cond_change;
+
+} fdqueue;
+
+#endif

--- a/headerfiles.mk
+++ b/headerfiles.mk
@@ -22,4 +22,6 @@ HDRS=	fifo.h \
 	constants.h \
 	monitor-client.h \
 	mdp_client.h \
-	sqlite-amalgamation-3070900/sqlite3.h
+	sqlite-amalgamation-3070900/sqlite3.h \
+	fdqueue.h \
+	parallel.h

--- a/log.h
+++ b/log.h
@@ -127,6 +127,7 @@ struct strbuf;
 #define FATAL(X)            FATALF("%s", (X))
 #define FATALF_perror(F,...) FATALF(F ": %s [errno=%d]", ##__VA_ARGS__, strerror(errno), errno)
 #define FATAL_perror(X)     FATALF_perror("%s", (X))
+#define OUT_OF_MEMORY       FATAL("Out of memory")
 
 #define WHYF(F,...)         (LOGF(LOG_LEVEL_ERROR, F, ##__VA_ARGS__), -1)
 #define WHY(X)              WHYF("%s", (X))

--- a/main.c
+++ b/main.c
@@ -33,6 +33,13 @@ int main(int argc, char **argv)
   srandomdev();
   server_save_argv(argc, (const char*const*)argv);
   cf_init();
+
+  /* workaround: when running tests, if no trace is logged before
+   * fdqueues_init(), then fd 0 will not be taken for logfile, so it will be
+   * used by a pipe (internal to fdqueues). When starting background server,
+   * fd 0 will be closed, so fdqueues would be broken. */
+  INFO("");
+
   int status = parseCommandLine(NULL, argv[0], argc - 1, (const char*const*)&argv[1]);
 #if defined WIN32
   WSACleanup();

--- a/overlay.c
+++ b/overlay.c
@@ -71,6 +71,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "serval.h"
 #include "conf.h"
 #include "rhizome.h"
+#include "parallel.h"
 #include "strbuf.h"
 
 int overlayMode=0;
@@ -84,6 +85,9 @@ int overlayServerMode()
   /* In overlay mode we need to listen to all of our sockets, and also to
      send periodic traffic. This means we need to */
   INFO("Running in overlay mode.");
+
+  multithread = 1;
+  main_fdqueue.thread = main_thread = pthread_self();
 
   /* Get keyring available for use.
      Required for MDP, and very soon as a complete replacement for the
@@ -104,16 +108,19 @@ int overlayServerMode()
      of wifi latency anyway, so we'll live with it.  Larger values will affect voice transport,
      and smaller values would affect CPU and energy use, and make the simulation less realistic. */
 
-#define SCHEDULE(X, Y, D) { \
+#define SCHEDULE_Q(X, Y, D, Q) { \
 static struct profile_total _stats_##X={.name="" #X "",}; \
 static struct sched_ent _sched_##X={\
   .stats = &_stats_##X, \
   .function=X,\
 }; \
-_sched_##X.alarm=(gettime_ms()+Y);\
-_sched_##X.deadline=(gettime_ms()+Y+D);\
+_sched_##X.alarm=(gettime_ms()+(Y));\
+_sched_##X.deadline=(gettime_ms()+(Y)+(D));\
+_sched_##X.fdqueue=(Q);\
 schedule(&_sched_##X); }
-  
+
+#define SCHEDULE(X, Y, D) SCHEDULE_Q(X,Y,D,NULL)
+
   /* Periodically check for server shut down */
   SCHEDULE(server_shutdown_check, 0, 100);
   
@@ -148,17 +155,23 @@ schedule(&_sched_##X); }
   SCHEDULE(overlay_interface_discover, 1, 100);
 
   /* Periodically advertise bundles */
-  SCHEDULE(overlay_rhizome_advertise, 1000, 10000);
+  SCHEDULE_Q(overlay_rhizome_advertise, 1000, 10000, &rhizome_fdqueue);
   
   /* Calculate (and possibly show) CPU usage stats periodically */
   SCHEDULE(fd_periodicstats, 3000, 500);
 
 #undef SCHEDULE
 
+  if (pthread_create(&rhizome_thread, NULL, rhizome_run, NULL)) {
+    FATAL("Cannot create rhizome pthread");
+  }
+
   // log message used by tests to wait for the server to start
   INFO("Server started, entering main loop");
   /* Check for activitiy and respond to it */
   while(fd_poll(&main_fdqueue, 1));
+
+  pthread_join(rhizome_thread, NULL);
 
   RETURN(0);
   OUT();

--- a/overlay.c
+++ b/overlay.c
@@ -158,7 +158,7 @@ schedule(&_sched_##X); }
   // log message used by tests to wait for the server to start
   INFO("Server started, entering main loop");
   /* Check for activitiy and respond to it */
-  while(fd_poll());
+  while(fd_poll(&main_fdqueue, 1));
 
   RETURN(0);
   OUT();

--- a/overlay_mdp_services.c
+++ b/overlay_mdp_services.c
@@ -28,8 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "rhizome.h"
 #include "crypto.h"
 #include "log.h"
-
-
+#include "parallel.h"
 
 int rhizome_mdp_send_block(struct subscriber *dest, unsigned char *id, uint64_t version, uint64_t fileOffset, uint32_t bitmap, uint16_t blockLength)
 {

--- a/overlay_mdp_services.c
+++ b/overlay_mdp_services.c
@@ -402,8 +402,20 @@ end:
   RETURN(ret);
 }
 
+static void rhizome_retrieve_and_advertise_manifest(const char *id_hex);
+
+void rhizome_retrieve_and_advertise_manifest_alarm(struct sched_ent *alarm)
+{
+  ASSERT_THREAD(rhizome_thread);
+  char *id_hex = alarm->context;
+  free(alarm);
+  rhizome_retrieve_and_advertise_manifest(id_hex);
+  free(id_hex);
+}
+
 static void rhizome_retrieve_and_advertise_manifest(const char *id_hex)
 {
+  ASSERT_THREAD(rhizome_thread);
   rhizome_manifest *manifest = rhizome_new_manifest();
   if (!manifest) OUT_OF_MEMORY;
   if (!rhizome_retrieve_manifest(id_hex, manifest)) {

--- a/overlay_mdp_services.c
+++ b/overlay_mdp_services.c
@@ -402,6 +402,16 @@ end:
   RETURN(ret);
 }
 
+static void rhizome_retrieve_and_advertise_manifest(const char *id_hex)
+{
+  rhizome_manifest *manifest = rhizome_new_manifest();
+  if (!manifest) OUT_OF_MEMORY;
+  if (!rhizome_retrieve_manifest(id_hex, manifest)) {
+    rhizome_advertise_manifest(manifest);
+  }
+  rhizome_manifest_free(manifest);
+}
+
 static int overlay_mdp_service_manifest_response(overlay_mdp_frame *mdp){
   int offset=0;
   char id_hex[RHIZOME_MANIFEST_ID_STRLEN];
@@ -410,13 +420,7 @@ static int overlay_mdp_service_manifest_response(overlay_mdp_frame *mdp){
     unsigned char *bar=&mdp->out.payload[offset];
     tohex(id_hex, &bar[RHIZOME_BAR_PREFIX_OFFSET], RHIZOME_BAR_PREFIX_BYTES);
     strcat(id_hex, "%");
-    rhizome_manifest *m = rhizome_new_manifest();
-    if (!m)
-      return WHY("Unable to allocate manifest");
-    if (!rhizome_retrieve_manifest(id_hex, m)){
-      rhizome_advertise_manifest(m);
-    }
-    rhizome_manifest_free(m);
+    rhizome_retrieve_and_advertise_manifest(id_hex);
     offset+=RHIZOME_BAR_BYTES;
   }
   

--- a/overlay_queue.c
+++ b/overlay_queue.c
@@ -60,6 +60,7 @@ static void overlay_send_packet(struct sched_ent *alarm);
 static int overlay_calc_queue_time(overlay_txqueue *queue, struct overlay_frame *frame);
 
 int overlay_queue_init(){
+  ASSERT_THREAD(main_thread);
   /* Set default congestion levels for queues */
   int i;
   for(i=0;i<OQ_MAX;i++) {
@@ -288,6 +289,7 @@ static void
 overlay_init_packet(struct outgoing_packet *packet, struct subscriber *destination, 
 		    int unicast, int packet_version,
 		    overlay_interface *interface, struct sockaddr_in addr){
+  ASSERT_THREAD(main_thread);
   packet->interface = interface;
   packet->context.interface = interface;
   packet->i = (interface - overlay_interfaces);
@@ -313,6 +315,7 @@ overlay_init_packet(struct outgoing_packet *packet, struct subscriber *destinati
 }
 
 int overlay_queue_schedule_next(time_ms_t next_allowed_packet){
+  ASSERT_THREAD(main_thread);
   if (next_packet.alarm==0 || next_allowed_packet < next_packet.alarm){
     
     if (!next_packet.function){
@@ -387,6 +390,7 @@ overlay_calc_queue_time(overlay_txqueue *queue, struct overlay_frame *frame){
 
 static void
 overlay_stuff_packet(struct outgoing_packet *packet, overlay_txqueue *queue, time_ms_t now){
+  ASSERT_THREAD(main_thread);
   struct overlay_frame *frame = queue->first;
   
   // TODO stop when the packet is nearly full?
@@ -612,6 +616,7 @@ overlay_stuff_packet(struct outgoing_packet *packet, overlay_txqueue *queue, tim
 // fill a packet from our outgoing queues and send it
 static int
 overlay_fill_send_packet(struct outgoing_packet *packet, time_ms_t now) {
+  ASSERT_THREAD(main_thread);
   int i;
   IN();
   // while we're looking at queues, work out when to schedule another packet
@@ -644,6 +649,7 @@ overlay_fill_send_packet(struct outgoing_packet *packet, time_ms_t now) {
 
 // when the queue timer elapses, send a packet
 static void overlay_send_packet(struct sched_ent *alarm){
+  ASSERT_THREAD(main_thread);
   struct outgoing_packet packet;
   bzero(&packet, sizeof(struct outgoing_packet));
   packet.seq=-1;
@@ -651,6 +657,7 @@ static void overlay_send_packet(struct sched_ent *alarm){
 }
 
 int overlay_send_tick_packet(struct overlay_interface *interface){
+  ASSERT_THREAD(main_thread);
   struct outgoing_packet packet;
   bzero(&packet, sizeof(struct outgoing_packet));
   packet.seq=-1;
@@ -663,6 +670,7 @@ int overlay_send_tick_packet(struct overlay_interface *interface){
 // de-queue all packets that have been sent to this subscriber & have arrived.
 int overlay_queue_ack(struct subscriber *neighbour, struct overlay_interface *interface, uint32_t ack_mask, int ack_seq)
 {
+  ASSERT_THREAD(main_thread);
   int interface_id = interface - overlay_interfaces;
   int i;
   time_ms_t now = gettime_ms();

--- a/parallel.c
+++ b/parallel.c
@@ -1,0 +1,48 @@
+/*
+ Copyright (C) 2012 Serval Project.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ 02110-1301, USA.
+ */
+
+#include <pthread.h>
+#include "parallel.h"
+#include "serval.h"
+
+pthread_t main_thread;
+pthread_t rhizome_thread;
+
+/* thread function, must have type: void *f(void *) */
+void *rhizome_run(void *arg) {
+  rhizome_fdqueue.thread = rhizome_thread = pthread_self();
+  while (fd_poll(&rhizome_fdqueue, 1));
+  return NULL;
+}
+
+void post_runnable(ALARM_FUNCP function, void *arg, fdqueue *fdq) {
+  time_ms_t now = gettime_ms();
+  static struct profile_total stats = { .name = "post_runnable/generic" };
+  struct sched_ent *alarm = malloc(sizeof(struct sched_ent));
+  if (!alarm) OUT_OF_MEMORY;
+  *alarm = (struct sched_ent) {
+    .function = function,
+    .alarm = now,
+    .deadline = now + 2000,
+    .stats = &stats,
+    .context = arg,
+    .fdqueue = fdq,
+  };
+  schedule(alarm);
+}

--- a/parallel.c
+++ b/parallel.c
@@ -21,6 +21,8 @@
 #include "parallel.h"
 #include "serval.h"
 
+int multithread;
+
 pthread_t main_thread;
 pthread_t rhizome_thread;
 
@@ -32,6 +34,9 @@ void *rhizome_run(void *arg) {
 }
 
 void post_runnable(ALARM_FUNCP function, void *arg, fdqueue *fdq) {
+  if (!multithread) {
+    fdq = &main_fdqueue;
+  }
   time_ms_t now = gettime_ms();
   static struct profile_total stats = { .name = "post_runnable/generic" };
   struct sched_ent *alarm = malloc(sizeof(struct sched_ent));

--- a/parallel.h
+++ b/parallel.h
@@ -101,4 +101,13 @@ void rhizome_advertise_manifest_alarm(struct sched_ent *alarm);
 /* *alarm->context is a char * (id_hex) */
 void rhizome_retrieve_and_advertise_manifest_alarm(struct sched_ent *alarm);
 
+/* rhizome_sync_send_requests argument */
+struct rssr_arg {
+  unsigned char sid[SID_SIZE];
+  struct rhizome_sync *state;
+};
+
+/* *alarm->context is a struct rssr_arg */
+void rhizome_sync_send_requests_alarm(struct sched_ent *alarm);
+
 #endif

--- a/parallel.h
+++ b/parallel.h
@@ -98,4 +98,7 @@ struct ram_arg {
 /* *alarm->context is a struct ram_arg */
 void rhizome_advertise_manifest_alarm(struct sched_ent *alarm);
 
+/* *alarm->context is a char * (id_hex) */
+void rhizome_retrieve_and_advertise_manifest_alarm(struct sched_ent *alarm);
+
 #endif

--- a/parallel.h
+++ b/parallel.h
@@ -22,6 +22,7 @@
 
 #include <pthread.h>
 #include "serval.h"
+#include "rhizome.h"
 
 extern int multithread;
 
@@ -73,5 +74,19 @@ struct rrc_arg {
 
 /* *alarm->context is a struct rrc_arg */
 void rhizome_received_content_alarm(struct sched_ent *alarm);
+
+/* rhizome_mdp_send_block argument */
+struct rmsb_arg {
+  int unicast;
+  unsigned char unicast_dest_sid[SID_SIZE];
+  unsigned char bid[RHIZOME_MANIFEST_ID_BYTES];
+  uint64_t version;
+  uint64_t file_offset;
+  uint32_t bitmap;
+  uint16_t block_length;
+};
+
+/* *alarm->context is a struct rmsb_arg */
+void rhizome_mdp_send_block_alarm(struct sched_ent *alarm);
 
 #endif

--- a/parallel.h
+++ b/parallel.h
@@ -1,0 +1,40 @@
+/*
+ Copyright (C) 2012 Serval Project.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 2
+ of the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ 02110-1301, USA.
+ */
+
+#ifndef __SERVALD_PARALLEL_H
+#define __SERVALD_PARALLEL_H
+
+#include <pthread.h>
+#include "serval.h"
+
+extern pthread_t main_thread;
+extern pthread_t rhizome_thread;
+
+#define ASSERT_THREAD(P)\
+  if (pthread_self() != (P)) {\
+    FATAL("Not called from the expected thread");\
+  }
+
+/* rhizome thread function */
+void *rhizome_run(void *arg);
+
+/* schedule a function call with the specified arguments on fdq */
+void post_runnable(ALARM_FUNCP function, void *arg, fdqueue *fdq);
+
+#endif

--- a/parallel.h
+++ b/parallel.h
@@ -23,11 +23,13 @@
 #include <pthread.h>
 #include "serval.h"
 
+extern int multithread;
+
 extern pthread_t main_thread;
 extern pthread_t rhizome_thread;
 
 #define ASSERT_THREAD(P)\
-  if (pthread_self() != (P)) {\
+  if (multithread && pthread_self() != (P)) {\
     FATAL("Not called from the expected thread");\
   }
 

--- a/parallel.h
+++ b/parallel.h
@@ -89,4 +89,13 @@ struct rmsb_arg {
 /* *alarm->context is a struct rmsb_arg */
 void rhizome_mdp_send_block_alarm(struct sched_ent *alarm);
 
+/* rhizome_advertise_manifest_alarm argument */
+struct ram_arg {
+  int manifest_all_bytes;
+  unsigned char manifestdata[MAX_MANIFEST_BYTES];
+};
+
+/* *alarm->context is a struct ram_arg */
+void rhizome_advertise_manifest_alarm(struct sched_ent *alarm);
+
 #endif

--- a/parallel.h
+++ b/parallel.h
@@ -39,4 +39,9 @@ void *rhizome_run(void *arg);
 /* schedule a function call with the specified arguments on fdq */
 void post_runnable(ALARM_FUNCP function, void *arg, fdqueue *fdq);
 
+/* following structs are used for passing args from one thread to another */
+
+/* *alarm->context is an overlay_mdp_frame */
+void overlay_mdp_dispatch_alarm(struct sched_ent *alarm);
+
 #endif

--- a/parallel.h
+++ b/parallel.h
@@ -61,4 +61,17 @@ void overlay_rhizome_saw_advertisements_alarm(struct sched_ent *alarm);
 /* *alarm->context is a struct overlay_buffer (payload) */
 void overlay_payload_enqueue_alarm(struct sched_ent *alarm);
 
+/* rhizome_received_content argument */
+struct rrc_arg {
+  int type;
+  unsigned char bidprefix[16];
+  uint64_t version;
+  uint64_t offset;
+  int count;
+  unsigned char* bytes;
+};
+
+/* *alarm->context is a struct rrc_arg */
+void rhizome_received_content_alarm(struct sched_ent *alarm);
+
 #endif

--- a/parallel.h
+++ b/parallel.h
@@ -44,6 +44,20 @@ void post_runnable(ALARM_FUNCP function, void *arg, fdqueue *fdq);
 /* *alarm->context is an overlay_mdp_frame */
 void overlay_mdp_dispatch_alarm(struct sched_ent *alarm);
 
+/* overlay_rhizome_saw_advertisements argument */
+struct orsa_arg {
+  int id;
+  struct overlay_buffer *payload;
+  unsigned char src_sid[SID_SIZE];
+  int src_reachable;
+  int use_new_sync_protocol;
+  struct sockaddr_in recvaddr;
+  time_ms_t now;
+};
+
+/* *alarm->context is a struct orsa_arg */
+void overlay_rhizome_saw_advertisements_alarm(struct sched_ent *alarm);
+
 /* *alarm->context is a struct overlay_buffer (payload) */
 void overlay_payload_enqueue_alarm(struct sched_ent *alarm);
 

--- a/parallel.h
+++ b/parallel.h
@@ -44,4 +44,7 @@ void post_runnable(ALARM_FUNCP function, void *arg, fdqueue *fdq);
 /* *alarm->context is an overlay_mdp_frame */
 void overlay_mdp_dispatch_alarm(struct sched_ent *alarm);
 
+/* *alarm->context is a struct overlay_buffer (payload) */
+void overlay_payload_enqueue_alarm(struct sched_ent *alarm);
+
 #endif

--- a/rhizome.h
+++ b/rhizome.h
@@ -335,7 +335,7 @@ int rhizome_list_manifests(struct cli_context *context, const char *service, con
 			   const char *sender_sid, const char *recipient_sid, 
 			   int limit, int offset, char count_rows);
 int rhizome_retrieve_manifest(const char *manifestid, rhizome_manifest *m);
-int rhizome_advertise_manifest(rhizome_manifest *m);
+int rhizome_advertise_manifest(int manifest_all_bytes, unsigned char *manifestdata);
 int rhizome_delete_bundle(const char *manifestid);
 int rhizome_delete_manifest(const char *manifestid);
 int rhizome_delete_payload(const char *manifestid);

--- a/rhizome_bundle.c
+++ b/rhizome_bundle.c
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <stdlib.h>
 #include "serval.h"
 #include "conf.h"
+#include "parallel.h"
 #include "rhizome.h"
 #include "str.h"
 
@@ -502,6 +503,7 @@ static void _log_manifest_trace(struct __sourceloc __whence, const char *operati
 
 rhizome_manifest *_rhizome_new_manifest(struct __sourceloc __whence)
 {
+  ASSERT_THREAD(rhizome_thread);
   if (manifest_first_free<0) {
     /* Setup structures */
     int i;
@@ -554,6 +556,7 @@ rhizome_manifest *_rhizome_new_manifest(struct __sourceloc __whence)
 
 void _rhizome_manifest_free(struct __sourceloc __whence, rhizome_manifest *m)
 {
+  ASSERT_THREAD(rhizome_thread);
   if (!m) return;
   int i;
   int mid=m->manifest_record_number;

--- a/rhizome_direct.c
+++ b/rhizome_direct.c
@@ -504,7 +504,7 @@ static int rhizome_sync_with_peers(int mode, int peer_count, const struct config
     rhizome_direct_sync_request *s = rhizome_direct_new_sync_request(rhizome_direct_http_dispatch, 65536, 0, mode, state);
     rhizome_direct_start_sync_request(s);
     if (rd_sync_handle_count > 0)
-      while (fd_poll() && rd_sync_handle_count > 0)
+      while (fd_poll(&rhizome_fdqueue, 1) && rd_sync_handle_count > 0)
 	;
   }
   return 0;

--- a/rhizome_direct_http.c
+++ b/rhizome_direct_http.c
@@ -877,7 +877,7 @@ void rhizome_direct_http_dispatch(rhizome_direct_sync_request *r)
 	       fetch the file for import is all handled asynchronously, so just
 	       wait for it to finish. */
 	    while (rhizome_any_fetch_active() || rhizome_any_fetch_queued())
-	      fd_poll();
+	      fd_poll(&rhizome_fdqueue, 1);
 	  }
 	
       } else if (type==1&&r->pushP) {

--- a/rhizome_fetch.c
+++ b/rhizome_fetch.c
@@ -1249,10 +1249,21 @@ int rhizome_write_content(struct rhizome_fetch_slot *slot, unsigned char *buffer
   OUT();
 }
 
+void rhizome_received_content_alarm(struct sched_ent *alarm) {
+  ASSERT_THREAD(rhizome_thread);
+  struct rrc_arg *arg = alarm->context;
+  free(alarm);
+  rhizome_received_content(arg->bidprefix, arg->version, arg->offset,
+                           arg->count, arg->bytes, arg->type);
+  free(arg->bytes);
+  free(arg);
+}
+
 int rhizome_received_content(unsigned char *bidprefix,
 			     uint64_t version, uint64_t offset,
 			     int count,unsigned char *bytes,int type)
 {
+  ASSERT_THREAD(rhizome_thread);
   IN();
   int i;
   for(i=0;i<NQUEUES;i++) {

--- a/rhizome_fetch.c
+++ b/rhizome_fetch.c
@@ -119,12 +119,12 @@ struct rhizome_fetch_candidate queue5[2];
 /* Static allocation of the queue structures.  Must be in order of ascending log_size_threshold.
  */
 struct rhizome_fetch_queue rhizome_fetch_queues[] = {
-  { .candidate_queue_size = NELS(queue0), .candidate_queue = queue0, .log_size_threshold =   10, .active = { .state = RHIZOME_FETCH_FREE } },
-  { .candidate_queue_size = NELS(queue1), .candidate_queue = queue1, .log_size_threshold =   13, .active = { .state = RHIZOME_FETCH_FREE } },
-  { .candidate_queue_size = NELS(queue2), .candidate_queue = queue2, .log_size_threshold =   16, .active = { .state = RHIZOME_FETCH_FREE } },
-  { .candidate_queue_size = NELS(queue3), .candidate_queue = queue3, .log_size_threshold =   19, .active = { .state = RHIZOME_FETCH_FREE } },
-  { .candidate_queue_size = NELS(queue4), .candidate_queue = queue4, .log_size_threshold =   22, .active = { .state = RHIZOME_FETCH_FREE } },
-  { .candidate_queue_size = NELS(queue5), .candidate_queue = queue5, .log_size_threshold = 0xFF, .active = { .state = RHIZOME_FETCH_FREE } }
+  { .candidate_queue_size = NELS(queue0), .candidate_queue = queue0, .log_size_threshold =   10, .active = { .state = RHIZOME_FETCH_FREE, .alarm = { .fdqueue = &rhizome_fdqueue } } },
+  { .candidate_queue_size = NELS(queue1), .candidate_queue = queue1, .log_size_threshold =   13, .active = { .state = RHIZOME_FETCH_FREE, .alarm = { .fdqueue = &rhizome_fdqueue } } },
+  { .candidate_queue_size = NELS(queue2), .candidate_queue = queue2, .log_size_threshold =   16, .active = { .state = RHIZOME_FETCH_FREE, .alarm = { .fdqueue = &rhizome_fdqueue } } },
+  { .candidate_queue_size = NELS(queue3), .candidate_queue = queue3, .log_size_threshold =   19, .active = { .state = RHIZOME_FETCH_FREE, .alarm = { .fdqueue = &rhizome_fdqueue } } },
+  { .candidate_queue_size = NELS(queue4), .candidate_queue = queue4, .log_size_threshold =   22, .active = { .state = RHIZOME_FETCH_FREE, .alarm = { .fdqueue = &rhizome_fdqueue } } },
+  { .candidate_queue_size = NELS(queue5), .candidate_queue = queue5, .log_size_threshold = 0xFF, .active = { .state = RHIZOME_FETCH_FREE, .alarm = { .fdqueue = &rhizome_fdqueue } } }
 };
 
 #define NQUEUES	    NELS(rhizome_fetch_queues)
@@ -904,11 +904,14 @@ int rhizome_suggest_queue_manifest_import(rhizome_manifest *m, const struct sock
     }
   }
 
+  /* no need to synchronize is_schedule() and schedule(): only this thread can
+     schedule sched_activate */
   if (!is_scheduled(&sched_activate)) {
     sched_activate.function = rhizome_start_next_queued_fetches;
     sched_activate.stats = &rsnqf_stats;
     sched_activate.alarm = gettime_ms() + rhizome_fetch_delay_ms();
     sched_activate.deadline = sched_activate.alarm + config.rhizome.idle_timeout;
+    sched_activate.fdqueue = &rhizome_fdqueue;
     schedule(&sched_activate);
   }
 

--- a/rhizome_http.c
+++ b/rhizome_http.c
@@ -172,6 +172,7 @@ success:
   server_alarm.stats=&server_stats;
   server_alarm.poll.fd = rhizome_server_socket;
   server_alarm.poll.events = POLLIN;
+  server_alarm.fdqueue = &rhizome_fdqueue;
   watch(&server_alarm);
   return 0;
 
@@ -297,6 +298,7 @@ void rhizome_server_poll(struct sched_ent *alarm)
 	request->alarm.poll.events=POLLIN;
 	request->alarm.alarm = gettime_ms()+RHIZOME_IDLE_TIMEOUT;
 	request->alarm.deadline = request->alarm.alarm+RHIZOME_IDLE_TIMEOUT;
+	request->alarm.fdqueue = &rhizome_fdqueue;
 	// watch for the incoming http request
 	watch(&request->alarm);
 	// set an inactivity timeout to close the connection

--- a/rhizome_packetformats.c
+++ b/rhizome_packetformats.c
@@ -175,6 +175,7 @@ static int append_bars(struct overlay_buffer *e, sqlite_retry_state *retry, cons
  */
 int64_t bundles_available=0;
 void overlay_rhizome_advertise(struct sched_ent *alarm){
+  ASSERT_THREAD(rhizome_thread);
   bundles_available=0;
   static int64_t bundle_last_rowid=INT64_MAX;
   

--- a/rhizome_sync.c
+++ b/rhizome_sync.c
@@ -463,7 +463,11 @@ int overlay_mdp_service_rhizome_sync(struct overlay_frame *frame, overlay_mdp_fr
       break;
   }
   ob_free(b);
-  rhizome_sync_send_requests(frame->source, state);
+  struct rssr_arg *arg = malloc(sizeof(struct rssr_arg));
+  if (!arg) OUT_OF_MEMORY;
+  memcpy(arg->sid, frame->source->sid, SID_SIZE);
+  arg->state = state;
+  post_runnable(rhizome_sync_send_requests_alarm, arg, &rhizome_fdqueue);
   return 0;
 }
 

--- a/serval.h
+++ b/serval.h
@@ -551,7 +551,12 @@ int overlay_queue_schedule_next(time_ms_t next_allowed_packet);
 int overlay_send_tick_packet(struct overlay_interface *interface);
 int overlay_queue_ack(struct subscriber *neighbour, struct overlay_interface *interface, uint32_t ack_mask, int ack_seq);
 
-int overlay_rhizome_saw_advertisements(int i, struct overlay_frame *f,  time_ms_t now);
+int overlay_rhizome_saw_advertisements(int i, struct overlay_buffer *payload,
+                                       unsigned char *src_sid,
+                                       int src_reachable,
+                                       int use_new_sync_protocol,
+                                       struct sockaddr_in recvaddr,
+                                       time_ms_t now);
 int rhizome_server_get_fds(struct pollfd *fds,int *fdcount,int fdmax);
 int rhizome_saw_voice_traffic();
 int overlay_saw_mdp_containing_frame(struct overlay_frame *f, time_ms_t now);

--- a/serval.h
+++ b/serval.h
@@ -308,6 +308,12 @@ struct call_stats{
   struct call_stats *prev;
 };
 
+#define MS_TO_TIMESPEC(MS, TS)\
+  (TS)->tv_sec = (MS) / 1000;\
+  (TS)->tv_nsec = ((MS) % 1000) * 1000000;
+
+#include "fdqueue.h"
+
 struct sched_ent;
 
 typedef void (*ALARM_FUNCP) (struct sched_ent *alarm);
@@ -325,6 +331,7 @@ struct sched_ent{
   time_ms_t deadline;
   struct profile_total *stats;
   int _poll_index;
+  fdqueue *fdqueue;
 };
 
 struct limit_state{
@@ -747,7 +754,7 @@ int _unwatch(struct __sourceloc whence, struct sched_ent *alarm);
 #define unschedule(alarm) _unschedule(__WHENCE__, alarm)
 #define watch(alarm)      _watch(__WHENCE__, alarm)
 #define unwatch(alarm)    _unwatch(__WHENCE__, alarm)
-int fd_poll();
+int fd_poll(fdqueue *fdqueue, int wait);
 
 void overlay_interface_discover(struct sched_ent *alarm);
 void overlay_packetradio_poll(struct sched_ent *alarm);

--- a/serval.h
+++ b/serval.h
@@ -788,18 +788,20 @@ int limit_is_allowed(struct limit_state *state);
 int limit_init(struct limit_state *state, int rate_micro_seconds);
 
 /* function timing routines */
-int fd_clearstats();
-int fd_showstats();
-int fd_checkalarms();
-int fd_func_enter(struct __sourceloc __whence, struct call_stats *this_call);
-int fd_func_exit(struct __sourceloc __whence, struct call_stats *this_call);
-void dump_stack(int log_level);
+int fd_clearstats(fdqueue *fdq);
+int fd_showstats(fdqueue *fdq);
+int fd_func_enter(struct __sourceloc __whence, fdqueue * fdq,
+                  struct call_stats *this_call);
+int fd_func_exit(struct __sourceloc __whence, fdqueue * fdq,
+                 struct call_stats *this_call);
+void dump_stack(fdqueue *fdq, int log_level);
+void dump_stacks(int log_level);
 
 #define IN() static struct profile_total _aggregate_stats={NULL,0,__FUNCTION__,0,0,0}; \
     struct call_stats _this_call={.totals=&_aggregate_stats}; \
-    fd_func_enter(__HERE__, &_this_call);
+    fd_func_enter(__HERE__, current_fdqueue(), &_this_call);
 
-#define OUT() fd_func_exit(__HERE__, &_this_call)
+#define OUT() fd_func_exit(__HERE__, current_fdqueue(), &_this_call)
 #define RETURN(X) do { OUT(); return (X); } while (0);
 #define RETURNNULL do { OUT(); return (NULL); } while (0);
 

--- a/server.c
+++ b/server.c
@@ -374,7 +374,7 @@ void signal_handler(int signal)
   
   LOGF(LOG_LEVEL_FATAL, "Caught signal %s", buf);
   LOGF(LOG_LEVEL_FATAL, "The following clue may help: %s",crash_handler_clue); 
-  dump_stack(LOG_LEVEL_FATAL);
+  dump_stacks(LOG_LEVEL_FATAL);
 
   serverCleanUp();
   exit(0);
@@ -387,8 +387,8 @@ void crash_handler(int signal)
   signame(buf, sizeof(buf), signal);
   LOGF(LOG_LEVEL_FATAL, "Caught signal %s", buf);
   LOGF(LOG_LEVEL_FATAL, "The following clue may help: %s",crash_handler_clue); 
-  dump_stack(LOG_LEVEL_FATAL);
-  
+  dump_stacks(LOG_LEVEL_FATAL);
+
   BACKTRACE;
   if (config.server.respawn_on_crash) {
     int i;

--- a/sourcefiles.mk
+++ b/sourcefiles.mk
@@ -40,6 +40,7 @@ SERVAL_SOURCES = \
 	$(SERVAL_BASE)overlay_packetformats.c \
 	$(SERVAL_BASE)overlay_payload.c \
 	$(SERVAL_BASE)packetformats.c \
+	$(SERVAL_BASE)parallel.c \
 	$(SERVAL_BASE)performance_timing.c \
 	$(SERVAL_BASE)randombytes.c \
 	$(SERVAL_BASE)route_link.c \

--- a/vomp_console.c
+++ b/vomp_console.c
@@ -358,7 +358,7 @@ int app_vomp_console(const struct cli_parsed *parsed, struct cli_context *contex
   watch(&stdin_state.alarm);
   
   while(monitor_client_fd!=-1){
-    fd_poll();
+    fd_poll(&main_fdqueue, 1);
   }
   
   unwatch(&stdin_state.alarm);


### PR DESCRIPTION
I recently [found](https://groups.google.com/forum/#!topic/serval-project-developers/kynmhNjv_To) that mdp packets and Rhizome stuff were executed on the same thread. Consequently, audio communications were broken during Rhizome synchronization.

I propose some code making all the Rhizome stuff executed in a separate POSIX thread (only in overlay mode, not necessary elsewhere).

With this code, I successfully exchange Rhizome bundles without impacting audio communications.
### Implementation

Here are the principles of my implementation (for more information, read the messages of the firsts commits).

The main idea is to use two fdqueue instances: one "main" and one "rhizome". In overlay mode, a new thread is started, which calls `fd_poll()` on the rhizome fdqueue.

An alarm (`sched_ent`) has now a field `fdqueue`, specifying on which fdqueue the alarm must be scheduled/watched. Thus, the main thread can schedule an alarm to be executed on the rhizome thread (and vice-versa).

Of course, the alarm data (its context) cannot be stack-stored (there is one stack per thread) and these alarms must be allocated dynamically, which implies quite a lot of changes. Commits with message beggining by "Alarm" create a wrapper to be scheduled on an fdqueue. Commits with message beggining by "Schedule" allocate parameters (if needed) and schedule an alarm to be executed on the other thread.
### Tests

All tests pass, except `FileTransferUnreliableBigMDP`.
This test sometimes [fails](https://github.com/servalproject/serval-dna/issues/67) even without my changes. If I change the filesize from 1MB to 500kB (in `setup_bugfile_common()` in `tests/rhizomeprotocol`), it pass.
