### PR TITLE
add MDP client library target to Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -125,6 +125,10 @@ libserval.so: $(SERVALD_OBJS) version.o
 	@echo LINK $@
 	@$(CC) $(CFLAGS) -Wall -shared -o $@ $(SERVALD_OBJS) version.o $(LDFLAGS)
 
+libmdpclient.so: $(MDP_CLIENT_OBJS) version.o
+	@echo LINK $@
+	@$(CC) $(CFLAGS) -Wall -shared -o $@ $(MDP_CLIENT_OBJS) version.o $(LDFLAGS)
+
 libmonitorclient.so: $(MONITOR_CLIENT_OBJS) version.o
 	@echo LINK $@
 	@$(CC) $(CFLAGS) -Wall -shared -o $@ $(MONITOR_CLIENT_OBJS) version.o $(LDFLAGS)


### PR DESCRIPTION
An MDP client library would be useful for software wanting to make use of the MDP overlay without needing the whole serval-dna library (e.g. I'm using the MDP client library in the Commotion Service Manager for fetching SAS keys).
