### PR TITLE
Removed unnecessary null check and wrong empty string checks

### DIFF
--- a/http_server.c
+++ b/http_server.c
@@ -1130,8 +1130,7 @@ static int http_request_start_body(struct http_request *r)
       if (   strcmp(r->request_header.content_type.type, "multipart") == 0
 	  && strcmp(r->request_header.content_type.subtype, "form-data") == 0
       ) {
-	if (   r->request_header.content_type.multipart_boundary == NULL
-	    || r->request_header.content_type.multipart_boundary[0] == '\0'
+	if (   r->request_header.content_type.multipart_boundary[0] == '\0'
 	) {
 	  IDEBUGF(r->debug, "Malformed HTTP %s request: Content-Type %s/%s missing boundary parameter",
 		r->verb, r->request_header.content_type.type, r->request_header.content_type.subtype);
@@ -2067,7 +2066,7 @@ static int _render_response(struct http_request *r)
   if (hr.header.content_length != CONTENT_LENGTH_UNKNOWN)
     strbuf_sprintf(sb, "Content-Length: %"PRIhttp_size_t"\r\n", hr.header.content_length);
   
-  if (hr.header.allow_origin)
+  if (strlen(hr.header.allow_origin) > 0)
     strbuf_sprintf(sb, "Access-Control-Allow-Origin: %s\r\n", hr.header.allow_origin);
   if (hr.header.allow_methods)
     strbuf_sprintf(sb, "Access-Control-Allow-Methods: %s\r\n", hr.header.allow_methods);

--- a/strbuf_helpers.c
+++ b/strbuf_helpers.c
@@ -936,15 +936,15 @@ strbuf strbuf_append_mime_content_type(strbuf sb, const struct mime_content_type
   strbuf_puts(sb, ct->type);
   strbuf_putc(sb, '/');
   strbuf_puts(sb, ct->subtype);
-  if (ct->charset) {
+  if (strlen(ct->charset) > 0) {
     strbuf_puts(sb, "; charset=");
     strbuf_append_quoted_string(sb, ct->charset);
   }
-  if (ct->multipart_boundary) {
+  if (strlen(ct->multipart_boundary) > 0) {
     strbuf_puts(sb, "; boundary=");
     strbuf_append_quoted_string(sb, ct->multipart_boundary);
   }
-  if (ct->format) {
+  if (strlen(ct->format) > 0) {
     strbuf_puts(sb, "; format=");
     strbuf_append_quoted_string(sb, ct->format);
   }
@@ -954,11 +954,11 @@ strbuf strbuf_append_mime_content_type(strbuf sb, const struct mime_content_type
 strbuf strbuf_append_mime_content_disposition(strbuf sb, const struct mime_content_disposition *cd)
 {
   strbuf_puts(sb, cd->type);
-  if (cd->name) {
+  if (strlen(cd->name) > 0) {
     strbuf_puts(sb, "; name=");
     strbuf_append_quoted_string(sb, cd->name);
   }
-  if (cd->filename) {
+  if (strlen(cd->filename) > 0) {
     strbuf_puts(sb, "; filename=");
     strbuf_append_quoted_string(sb, cd->filename);
   }


### PR DESCRIPTION
There where some null checks in referenced structs, that should better be checks for empty strings (in my opinion). Using LLVM those lead to a compiler error.
