### PR TITLE
Errors appearing when building in current openwrt trunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ test.*.log
 /testlog
 /coverage_html
 *.info
+serval.xcodeproj

--- a/Makefile.in
+++ b/Makefile.in
@@ -75,7 +75,13 @@ INSTALL_DATA=   $(INSTALL) -m 644
 # More warnings, discover problems that only happen on some archs
 CFLAGS+=-Wextra
 # Security enhancements from Debian
-CFLAGS+=-Wformat -Werror=format-security -D_FORTIFY_SOURCE=2
+CFLAGS+=-Wformat -Werror=format-security
+
+# Set D_FORTIFY_SOURCE if not set yet.
+ifeq (,$(findstring D_FORTIFY_SOURCE,$(CFLAGS)))
+    # D_FORTIFY_SOURCE is not set
+    CFLAGS += -D_FORTIFY_SOURCE=2
+endif
 
 DEFS=	@DEFS@
 

--- a/rhizome.h
+++ b/rhizome.h
@@ -768,7 +768,7 @@ struct rhizome_read
   
   uint64_t hash_offset;
   SHA512_CTX sha512_context;
-  char verified;
+  signed char verified;
   
   uint64_t blob_rowid;
   int blob_fd;


### PR DESCRIPTION
The D_FORTIFY_SOURCE compiler option defined twice, which leads to a error, as well as the missing sign definition of the verified variable. 
The two commits are possible fixes for this issue.
