### PR TITLE
Set manifest pointer to null to stop double free when database is slow

### DIFF
--- a/rhizome_restful.c
+++ b/rhizome_restful.c
@@ -981,6 +981,7 @@ static int restful_rhizome_(httpd_request *r, const char *remainder)
       break;
     case RHIZOME_BUNDLE_STATUS_BUSY:
       rhizome_manifest_free(r->manifest);
+      r->manifest = NULL;
       return http_request_rhizome_response(r, 0, NULL);
     case RHIZOME_BUNDLE_STATUS_ERROR:
       rhizome_manifest_free(r->manifest);


### PR DESCRIPTION
Fixes serval crash on low end devices which is caused by the database being locked for too long, which in turn sends the busy signal which double frees the manifest. 